### PR TITLE
#164275534 Upgrade Django 2.1.2 to Django 2.1.7

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -5,7 +5,7 @@ chardet==3.0.4
 coreapi==2.3.3
 coreschema==0.0.4
 decorator==4.3.0
-Django==2.1.2
+Django==2.1.7
 django-environ==0.4.5
 django-extensions==2.1.3
 django-filter==2.0.0


### PR DESCRIPTION
#### What does this PR do?
Upgrades Django 2.1.2 to Django 2.1.7. 
#### Description of Task to be completed?
Ensure the Django version is upgraded from Django 2.1.2 to 2.1.7.
This is done by installing Django version 2.1.7 the updating the requirements.txt file to reflect the change.
#### How should this be manually tested?
After cloning or pulling the develop branch, run the following command on your terminal:
pip install -r requirements.txt
#### Any background context you want to provide?
Django 2.x is the latest release of Django with full support of Python 3.x series.
#### What are the relevant pivotal tracker stories?
#164275556

