### PR TITLE
#164722615 Add environment variable for swagger url

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -34,8 +34,6 @@ DEFAULT_SERVER_EMAIL='mail <no-reply@site.me>'
 DJANGO_SENTRY_DSN=''
 DJANGO_SENTRY_LOG_LEVEL=20
 
-JWT_SECRET_KEY='SECRET_KEY'=your jwt secret key
+JWT_SECRET_KEY=your jwt secret key
+SWAGGER_URL=the url to the server running the application
 
-# for testing
-Google_id_token_for_registered_user=your token here
-Google_id_token_for_unregistered_user=your_token_here

--- a/api/config/swagger.py
+++ b/api/config/swagger.py
@@ -6,6 +6,7 @@ from rest_framework import response
 from rest_framework.permissions import AllowAny
 from rest_framework_jwt.authentication import JSONWebTokenAuthentication
 import coreapi
+import os
 
 
 @api_view()
@@ -15,7 +16,7 @@ import coreapi
 def schema_view_swagger(request):
     schema = coreapi.Document(
         title='Questioner API',
-        url='https://questioners-two-staging.herokuapp.com/',  # replace with your url
+        url=os.getenv('SWAGGER_URL'), 
         content={
             'Users': {
                 'signup': coreapi.Link(


### PR DESCRIPTION
### What does this PR do?
- Changes the swagger url to an environment variable
### How to manually test 
- In your .env, add a variable `SWAGGER_URL` with the address of the server of your running application. *e.g.* `https://questioners-two-staging.herokuapp.com/`
### Relevant Pivotal Tracker Stories?
[#164722615](https://www.pivotaltracker.com/n/projects/2315729/stories/164722615)