### PR TITLE
#164822926 Fix the social auth functionality

### DIFF
--- a/api/config/swagger.py
+++ b/api/config/swagger.py
@@ -82,7 +82,7 @@ def schema_view_swagger(request):
                     description='Resend account activation email'
                 ),
                 'social signup': coreapi.Link(
-                    url='/api/auth/social/signup',
+                    url='/api/auth/google/signup',
                     action='POST',
                     fields=[
                         coreapi.Field(
@@ -114,7 +114,7 @@ def schema_view_swagger(request):
                     description='Using basic authentication to login'
                 ),
                 'google auth': coreapi.Link(
-                    url='/api/auth/google_oauth2/',
+                    url='/api/auth/google/login',
                     action='POST',
                     fields=[
                         coreapi.Field(


### PR DESCRIPTION
#### What does this PR do?
- Fix the social auth url path
- User can sign-in using google 
#### How should this be manually tested?
 - After cloning the repo:
```
$ git checkout  bg-fix-social-164822926
```
- Pick the `id_token` from [Oauth Playground](https://developers.google.com/oauthplayground/)
- Pass the `id_token` to the body
#### What are the relevant pivotal tracker stories?
[#164822926](https://www.pivotaltracker.com/n/projects/2315729/stories/164822926)
#### Screenshots (if appropriate)
![oauth](https://user-images.githubusercontent.com/7009215/54940051-078f3000-4f3b-11e9-982c-4728eec2f7e1.png)
